### PR TITLE
Prevent scrolling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const FamewallEmbed = ({ wallUrl }) => {
       id={embedId}
       src={`https://embed.famewall.io/wall/${wallUrl}`}
       frameBorder='0'
-      scrolling='yes'
+      scrolling={false}
       width='100%'
       style={{
         border: 0


### PR DESCRIPTION
This change intents to fix two issues which can happen randomly:

- Empty wall: the iframe has a null height.
- Wall with a scrollbar: the iframe height must be something like 100px tall.

I've just deployed the fix for [SaveOurSocial](https://saveoursocial.co/) and it seems to work:

- Without the fix: the issues above happen 1 time out of 2 or 3.
- With the fix: no issue.

It's hard to tell the cause of these issues. I suspect they are related with loading time. If you want to investigate rather than accepting this PR blindly, I suggest you to artificially add time at wall loading (ie. wait before you remove the blue loader and replace it with the wall) and see if that makes the bug reproductible.